### PR TITLE
Add aarch64 architecture to installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ function download() {
 	case "${ARCH}" in
 	x86_64) ARCH="ArchitectureX86" ;;
 	arm64) ARCH="ArchitectureArm64" ;;
+	aarch64) ARCH="ArchitectureArm64" ;;
 	*)
 		echo "Unsupported architecture: ${ARCH}"
 		exit 2


### PR DESCRIPTION
Fixes #5

I tested in on Ubuntu aarch64 in AWS EC2 and it worked.