### PR TITLE
Fix zsh completion error on fresh macOS installations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,8 +72,12 @@ function setupShells() {
 	if [ -f "$HOME/.zshrc" ]; then
 		echo "Configuring zsh"
 		appendIfNotPresent "$HOME/.zshrc" "export PATH=\"\$HOME/.local/bin:\$PATH\""
-		appendIfNotPresent "$HOME/.zshrc" "autoload -Uz compinit 2>/dev/null && compinit 2>/dev/null"
-		appendIfNotPresent "$HOME/.zshrc" "eval \"\$(duckman completion zsh)\""
+		appendIfNotPresent "$HOME/.zshrc" "# duckman completion (requires compinit)"
+		appendIfNotPresent "$HOME/.zshrc" '(( $+functions[compdef] )) && eval "$(duckman completion zsh)"'
+
+		echo "Note (zsh): duckman autocomplete needs zsh completion enabled (compinit)."
+		echo "If autocomplete doesn't work, add this above the duckman completion line in ~/.zshrc:"
+		echo "  autoload -Uz compinit && compinit"
 	fi
 
 	# Fish

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,7 @@ function setupShells() {
 	if [ -f "$HOME/.zshrc" ]; then
 		echo "Configuring zsh"
 		appendIfNotPresent "$HOME/.zshrc" "export PATH=\"\$HOME/.local/bin:\$PATH\""
+		appendIfNotPresent "$HOME/.zshrc" "autoload -Uz compinit 2>/dev/null && compinit 2>/dev/null"
 		appendIfNotPresent "$HOME/.zshrc" "eval \"\$(duckman completion zsh)\""
 	fi
 


### PR DESCRIPTION
### Problem
On fresh macOS installations with zsh, users encounter the following error when opening a new terminal:

```bash
(eval):2: command not found: compdef
```

This occurs because the zsh completion system hasn't been initialized before the `duckman completion zsh` command runs, which requires the `compdef` function. On fresh installations, `compdef` is only available after `compinit` has been called.

### Solution
This PR adds an initialization step that ensures `compinit` runs before loading the duckman completion script. This guarantees that the completion system is properly initialized when `compdef` is called.

**Changes:**
- Added `autoload -Uz compinit 2>/dev/null && compinit 2>/dev/null` line before the completion eval
- The `2>/dev/null` suppresses any warnings if compinit has already been called (making it safe to run multiple times)

### Testing
I've tested this fix on a fresh macOS installation. After adding the new line, opening a new terminal no longer produces the `command not found: compdef` error, and duckman completion works correctly. I also verified it works correctly with oh-my-zsh installed, where compinit is already called by the framework.
